### PR TITLE
Fix: Server now includes file path creation

### DIFF
--- a/src/shared/models.rs
+++ b/src/shared/models.rs
@@ -30,34 +30,11 @@ impl FileRow {
         self.last_modified
     }
 
-    pub fn set_path(&mut self, path: String) {
-        self.path = path;
-    }
-
     pub fn set_hash(&mut self, hash: String) {
         self.hash = hash;
     }
 
     pub fn set_last_modified(&mut self, last_modified: DateTime<Utc>) {
         self.last_modified = last_modified;
-    }
-}
-
-pub struct FileData {
-    filename: String,
-    last_modified: String
-}
-
-impl FileData {
-    pub fn new(filename: String, last_modified: String) -> Self {
-        Self { filename, last_modified }
-    }
-
-    pub fn filename(&self) -> &str {
-        &self.filename
-    }
-
-    pub fn last_modified(&self) -> &str {
-        &self.last_modified
     }
 }


### PR DESCRIPTION
- Introduced `path` multipart field
- Upon receiving this path, it is linked to the corresponding file. When file is created, path is created first then file is saved

This PR closes #19 